### PR TITLE
Update release note url to accurate release branch

### DIFF
--- a/ossrelease/msgs/community_pkg
+++ b/ossrelease/msgs/community_pkg
@@ -3,7 +3,7 @@ Hi all,
 We have announced the _salt_version_ release of Salt.
 
 Release notes can be found here:
-https://docs.saltstack.com/en/develop/topics/releases/_salt_version_.html
+https://docs.saltstack.com/en/latest/topics/releases/_salt_version_.html
 
 Sources are available on PyPI:
 https://pypi.python.org/pypi/salt/_salt_version_

--- a/ossrelease/msgs/live_latest
+++ b/ossrelease/msgs/live_latest
@@ -1,7 +1,7 @@
 We are pleased to announce the _salt_version_ release of Salt!
 
 Release notes can be found here:
-https://docs.saltstack.com/en/develop/topics/releases/_salt_version_.html
+https://docs.saltstack.com/en/latest/topics/releases/_salt_version_.html
 Instructions for installing the latest packages can be found here:
 http://repo.saltstack.com
 

--- a/ossrelease/msgs/live_prev
+++ b/ossrelease/msgs/live_prev
@@ -1,7 +1,7 @@
 We are pleased to announce the _salt_version_ release of Salt!
 
 Release notes can be found here:
-https://docs.saltstack.com/en/develop/topics/releases/_salt_version_.html
+https://docs.saltstack.com/en/_branch_/topics/releases/_salt_version_.html
 Instructions for installing the latest packages can be found here:
 http://repo.saltstack.com
 


### PR DESCRIPTION
the url for the release notes link pointed to develop. This switches the url to the appropriate release branch.