### PR TITLE
Add "branch-update" helper scripts

### DIFF
--- a/branch-updates/bootstrap.sh
+++ b/branch-updates/bootstrap.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# This script pulls any new changes from Saltstack/salt-bootstrap.git to local repo
+# And then pushes those changes to rallytime/salt-bootstrap.git.
+
+cd ~/SaltStack/salt-bootstrap/
+
+# Check if there are any unstaged changes
+if [ -n "$(git status --porcelain)" ]; then 
+    git status
+    echo "\nChanges present - Exiting.";
+else 
+    # Update all relevant, constant branches
+    for branch in stable develop
+    do
+        git checkout $branch
+        git pull upstream $branch
+        git push rallytime $branch
+    done
+fi
+

--- a/branch-updates/jenkins.sh
+++ b/branch-updates/jenkins.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# This script pulls any new changes from Saltstack/salt-jenkins.git to local
+# repo and then pushes those changes to rallytime/salt-jenkins.git.
+
+cd ~/SaltStack/salt-jenkins/
+
+# Check if there are any unstaged changes
+if [ -n "$(git status --porcelain)" ]; then 
+    git status
+    echo "\nChanges present - Exiting.";
+else 
+    # Update all relevant, constant branches
+    for branch in 2017.7 2018.3 fluorine master
+    do
+        git checkout $branch
+        git pull upstream $branch
+        git push rallytime $branch
+    done
+fi

--- a/branch-updates/salt.sh
+++ b/branch-updates/salt.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# This script pulls any new changes from Saltstack/salt.git to local repo
+# And then pushes those changes to rallytime/salt.git.
+
+cd ~/SaltStack/salt/
+
+# Check if there are any unstaged changes
+if [ -n "$(git status --porcelain)" ]; then 
+    git status
+    echo "\nChanges present - Exiting.";
+else 
+    # Update all relevant, constant branches
+    for branch in 2017.7 2018.3 fluorine develop
+    do
+        git checkout $branch
+        git pull upstream $branch
+        git push rallytime $branch
+    done
+fi


### PR DESCRIPTION
Adds some sample scripts for updating main release branches for various salt repos such as:
- salt
- salt-bootstrap
- salt-jenkins

These files should be updated (if used by others) as branches are added (new feature branches), go out of use (when 2017.7 is retired), or are renamed (feature branches become release branches).

*NOTE*: These are specific to _my_ setup for git clone paths and remote names. Edit for your use as needed. I highly advise looking at each line of these scripts before using them.

Someday it might make sense to transfer these to python files with configurable variables (paths, git remotes, etc.) but this will work for now if people would like.