### PR TITLE
Add salt-utils search helper file

### DIFF
--- a/helpers/salt-utils.sh
+++ b/helpers/salt-utils.sh
@@ -1,0 +1,2 @@
+egrep -r "salt\\.utils\\.(`egrep '^def ' salt/utils/__init__.py | cut -f2 -d' ' | cut -f1 -d'(' | tr '\n' '|' | sed 's/.$//'`)" . | egrep -v '^Binary' | fgrep -v "salt/utils/__init__.py" | fgrep -v "doc/topics/releases" | fgrep -v "doc/man/salt"
+


### PR DESCRIPTION
This file is used to help search for old uses of the `salt.utils.<function>` so they can be replaced with `salt.utils.<filename>.<function>` in the following salt branches:
- 2018.3
- fluorine

The utils path file changes apply to neither the `2017.7` nor the `develop` branches.